### PR TITLE
cleanup(tap): Minor cleanup items

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "api": "nodemon --watch ./tests/bdd --watch ./repos/backend --watch ./config --exec 'node ./repos/backend/index.js'",
+    "api": "nodemon --watch ./repos/backend --watch ./config --exec 'node ./repos/backend/index.js'",
     "clean": "cd node_modules/keg-core; yarn clean",
     "clean:install": "yarn clean:full; yarn install",
     "clean:full": "yarn clean; yarn clean:nm; yarn install",

--- a/tasks/definitions/tap/start.js
+++ b/tasks/definitions/tap/start.js
@@ -29,6 +29,8 @@ module.exports = {
     alias: ['st'],
     action: startHerkin,
     example: 'test:start',
+    // Merge the default task options with these custom task options
+    mergeOptions: true,
     description : 'Starts all services. (Local Webserver and Docker Container)',
     options: sharedOptions('start', {
         launch: {


### PR DESCRIPTION
**Ticket**: [ZEN-436](https://jira.simpleviewtools.com/browse/ZEN-436)

## Context

* I saw a few things that needed to be cleaned up

## Goal

* Clean up some things

## Updates

* Updated API to not restart on bdd test folder changes
* Update cucumber run to add jest args only if the matching param is exists
* Updated the jestConfig and test path to be relative to the docker tap root
* Added merge options key to the tap start task
  * This allows the options from the default task to be merged with the custom task options

## Testing

### Setup
* `keg herkin && keg pr 9` to switch to this branch
* Also pull down the latest keg-cli changes for the `ZEN-463-push-pull-tasks` branch
* Next, delete `.kegConfig/herkin-development.env` file if it exists
  * Or comment out the KEG_IMAGE_FROM env  

**Test 1**
* Start the  `keg herkin start --from keg-herkin:zen-436-create-task`
  * Added the from argument, should do technically the same thing as  adding `KEG_IMAGE_FROM` env to `.kegConfig/herkin-development.env`
  * It should use the above image when pulling and starting the tap, instead  of the `keg-herkin:master` image

**Test 2**
* Once keg-herkin is started, in another terminal window
* Run the command `keg herkin cucumber test`
  * Ensure the command runs as expected

