### PR TITLE
Hotfix Cucumber Test Directory

### DIFF
--- a/tasks/definitions/cucumber/run.js
+++ b/tasks/definitions/cucumber/run.js
@@ -74,8 +74,8 @@ module.exports = {
         default: 'configs/jest.cucumber.config.js'
       },
       testDir: {
-        description: 'Path to the tests directory within the docker container',
-        default: 'tests/bdd'
+        description: 'Path to the tests mount within the docker container',
+        default: 'tests'
       }
     }, [
       'allBrowsers',


### PR DESCRIPTION
## Goal/Context

* the task for `keg herkin cucumber test` looks inside of `/keg/tap/tests/bdd` by default for feature files to run
* but this is too specific -- the consumer may not have the `/bdd` in their tests directory, and this command would fail for them
* it worked before because testing with the example app coincidentally had the right folder structure
* it only needs to look at `/keg/tap/tests` to find all features, regardless of the consumer's test folder structure


## Updates

* `tasks/definitions/cucumber/run.js`
  * updated `testDir` path to be 'tests'

## Testing
* keg pr 16
* `keg herkin start --config ./repos/example/herkin.config.js`
* `keg herkin cucumber test`
* verify tests pass
