### PR TITLE
Zen 547 save feature file (backend)

### DIFF
--- a/container/mutagen.yml
+++ b/container/mutagen.yml
@@ -84,27 +84,27 @@ actions:
         - yarn dev
   jsutils:
     install:
-      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      location: /keg/tap/node_modules/@keg-hub/jsutils
       privileged: true
       cmds:
         - yarn install
     build:
-      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      location: /keg/tap/node_modules/@keg-hub/jsutils
       privileged: true
       cmds:
         - yarn build
     start:
-      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      location: /keg/tap/node_modules/@keg-hub/jsutils
       privileged: true
       detach: true
       cmds:
         - yarn dev
     copyRoot:
-      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      location: /keg/tap/node_modules/@keg-hub/jsutils
       privileged: true
       cmds:
         - rm -rf /keg/tap/node_modules/@keg-hub/jsutils/build
-        - cp -R /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils/build /keg/tap/node_modules/@keg-hub/jsutils/build
+        - cp -R /keg/tap/node_modules/@keg-hub/jsutils/build /keg/tap/node_modules/@keg-hub/jsutils/build
   retheme:
     install:
       location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme

--- a/container/values.yml
+++ b/container/values.yml
@@ -37,7 +37,7 @@ env:
   DOC_COMPONENTS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
   DOC_RETHEME_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
   DOC_RESOLVER_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
-  DOC_JSUTILS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+  DOC_JSUTILS_PATH: /keg/tap/node_modules/@keg-hub/jsutils
   DOC_PARKIN_PATH: /keg/tap/node_modules/@ltipton/parkin
 
   # Default port of the app to expose from the container

--- a/repos/backend/endpoints/files.js
+++ b/repos/backend/endpoints/files.js
@@ -10,10 +10,9 @@ const path = require('path')
 
 const saveFile = (app, config) => async (req, res) => {
   try {
-    const file = req.params.file
-    const content = req.params.content
-    const meta = await saveTestFile(config, file)
-
+    const path = req.body.path
+    const content = req.body.content
+    const meta = await saveTestFile(config, path, content)
     return apiResponse(req, res, meta || {}, 200)
   }
   catch(err){

--- a/repos/backend/endpoints/files.js
+++ b/repos/backend/endpoints/files.js
@@ -10,17 +10,17 @@ const path = require('path')
 
 const saveFile = (app, config) => async (req, res) => {
   try {
-    const path = req.body.path
-    if (!path)
+    const location = req.body.path
+    if (!location)
     return apiErr(
       req, 
       res, 
-      new Error(`[API - Files] Save failed: 'path' required`), 
+      new Error(`[API - Files] Save failed: location required`), 
       400
     )
 
     const content = req.body.content
-    const meta = await saveTestFile(config, path, content)
+    const meta = await saveTestFile(config, location, content)
     return apiResponse(req, res, meta || {}, 200)
   }
   catch(err){

--- a/repos/backend/endpoints/files.js
+++ b/repos/backend/endpoints/files.js
@@ -12,12 +12,12 @@ const saveFile = (app, config) => async (req, res) => {
   try {
     const location = req.body.path
     if (!location)
-    return apiErr(
-      req, 
-      res, 
-      new Error(`[API - Files] Save failed: location required`), 
-      400
-    )
+      return apiErr(
+        req,
+        res,
+        new Error(`[API - Files] Save failed: location required`), 
+        400
+      )
 
     const content = req.body.content
     const meta = await saveTestFile(config, location, content)

--- a/repos/backend/endpoints/files.js
+++ b/repos/backend/endpoints/files.js
@@ -11,6 +11,14 @@ const path = require('path')
 const saveFile = (app, config) => async (req, res) => {
   try {
     const path = req.body.path
+    if (!path)
+    return apiErr(
+      req, 
+      res, 
+      new Error(`[API - Files] Save failed: 'path' required`), 
+      400
+    )
+
     const content = req.body.content
     const meta = await saveTestFile(config, path, content)
     return apiResponse(req, res, meta || {}, 200)

--- a/repos/backend/libs/fileSys/testFiles.js
+++ b/repos/backend/libs/fileSys/testFiles.js
@@ -64,7 +64,8 @@ const saveTestFile = async (config, fullPath, content) => {
   const [err, success] = await writeFile(fullPath, content)
 
   if (err) {
-    const pathError = new Error(`[API - Files] Save failed: ${fullPath}`)
+    console.log(err)
+    const pathError = new Error(`[API - Files] Save failed: ${fullPath} - ${err.message}`)
     pathError.status = 404
     throw pathError
   }

--- a/repos/backend/libs/fileSys/testFiles.js
+++ b/repos/backend/libs/fileSys/testFiles.js
@@ -49,20 +49,30 @@ const getTestFile = async (config, testPath) => {
   } 
 }
 
+/**
+ * 
+ * @param {Object} config 
+ * @param {string} fullPath
+ * @param {string} content 
+ */
+const saveTestFile = async (config, fullPath, content) => {
 
-const saveTestFile = async (config, testPath, content) => {
   const { testsRoot } = config.paths
-  const fullPath = path.join(testsRoot, testPath)
+  const inTestRoot = fullPath.startsWith(testsRoot)
+  if (!inTestRoot) throw new Error(`[API - Files] Filepath must be within '${testsRoot}': received '${fullPath}'`)
 
-  await checkPath(fullPath)
+  const [err, success] = await writeFile(fullPath, content)
 
-  // TODO: double check that writeFile returns a value
-  const saved = await writeFile(fullPath, content)
+  if (err) {
+    const pathError = new Error(`[API - Files] Save failed: ${fullPath}`)
+    pathError.status = 404
+    throw pathError
+  }
 
   return {
     fullPath,
-    testPath,
-    success: Boolean(saved),
+    fileName: path.basename(fullPath),
+    success: Boolean(success),
   }
 }
 

--- a/repos/backend/libs/fileSys/testFiles.js
+++ b/repos/backend/libs/fileSys/testFiles.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { readFile, removeFile, writeFile, pathExists } = require('./fileSys')
-
+const { validFilename } = require('@keg-hub/jsutils')
 /**
  * Checks that the file path exists
  * @param {String} path - file path to check
@@ -58,6 +58,7 @@ const getTestFile = async (config, testPath) => {
 const saveTestFile = async (config, fullPath, content) => {
 
   const { testsRoot } = config.paths
+  if (!validFilename(path.basename(fullPath))) throw new Error(`[API - Files] Filename is invalid!`)
   const inTestRoot = fullPath.startsWith(testsRoot)
   if (!inTestRoot) throw new Error(`[API - Files] File must be saved to the mounted test folder!`)
 

--- a/repos/backend/libs/fileSys/testFiles.js
+++ b/repos/backend/libs/fileSys/testFiles.js
@@ -59,7 +59,7 @@ const saveTestFile = async (config, fullPath, content) => {
 
   const { testsRoot } = config.paths
   const inTestRoot = fullPath.startsWith(testsRoot)
-  if (!inTestRoot) throw new Error(`[API - Files] Filepath must be within '${testsRoot}': received '${fullPath}'`)
+  if (!inTestRoot) throw new Error(`[API - Files] Filepath must have rootPath '${testsRoot}': received '${fullPath}'`)
 
   const [err, success] = await writeFile(fullPath, content)
 

--- a/repos/backend/libs/fileSys/testFiles.js
+++ b/repos/backend/libs/fileSys/testFiles.js
@@ -59,7 +59,7 @@ const saveTestFile = async (config, fullPath, content) => {
 
   const { testsRoot } = config.paths
   const inTestRoot = fullPath.startsWith(testsRoot)
-  if (!inTestRoot) throw new Error(`[API - Files] Filepath must have rootPath '${testsRoot}': received '${fullPath}'`)
+  if (!inTestRoot) throw new Error(`[API - Files] File must be saved to the mounted test folder!`)
 
   const [err, success] = await writeFile(fullPath, content)
 

--- a/repos/backend/libs/fileSys/testFiles.js
+++ b/repos/backend/libs/fileSys/testFiles.js
@@ -50,7 +50,7 @@ const getTestFile = async (config, testPath) => {
 }
 
 /**
- * 
+ * Save file at a given location. file should be located in the test root path
  * @param {Object} config 
  * @param {string} fullPath
  * @param {string} content 


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-547)

## Context

* we need the backend api to support saving files
* File should be saved based on the custom test root path
* frontend implementation is handled on a diff ticket https://jira.simpleviewtools.com/browse/ZEN-533
 
## Goal

* Update the `save` endpoint to allow saving files relative to the custom test root path
* Should throw an error if the given path does not match the test root path

## Updates

* `repos/backend/endpoints/files.js`
  * update to read from the body prop
* `repos/backend/libs/fileSys/testFiles.js`
  * update to save the file at the given location if it's relative to the test root path   

## Testing

### Setup
* Pull this branch
* run `keg herkin start --config ./repos/example/herkin.config.js --from keg-herkin:zen-547-save-feature-file`
  * this mounts the tests dir of `repos/example` 
* utilize Postman to make a POST call to http://0.0.0.0:5005/files/save
  * [example](https://user-images.githubusercontent.com/3317835/108562912-d6057780-72bd-11eb-9303-0d08f920b06e.png)
* Execute the call with Body:
```JSON
"path" : "some/path"
"content": "some string content" 
``` 
 
### Test 1
* Execute a POST call with the following body:
```JSON
	"path": "/keg/tap/tests/bdd/features/fooBar.feature",
	"content": "new content"
```
* Verify that the call is successful and the file `fooBar.feature` is also added locally at `repos/example/tests/bdd/features`
  * [postman result](https://user-images.githubusercontent.com/3317835/108563661-0568b400-72bf-11eb-8ffb-2b86e3ab5332.png)
  * [file added](https://user-images.githubusercontent.com/3317835/108563700-19acb100-72bf-11eb-805f-5531c55f74d0.png)
* Run the POST call again on an existing path. i.e `/keg/tap/tests/bdd/features/example.feature`
* Ensure that it updates the file with the new content

### Test 2
 * Run the POST call with an invalid test path. (i.e `/Desktop/features/fooBar.feature`)
 * Verify that it fails and returns an error message
   * [image](https://user-images.githubusercontent.com/3317835/108563896-7dcf7500-72bf-11eb-9a8b-210d5a4841de.png)
* **Note:**
  * This `rootPath` is dynamic and is determined by the consumer's herkin config