### PR TITLE
ZEN-543: Develop Tag

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,7 +8,7 @@ ARG PLAYWRIGHT_IMAGE_FROM=mcr.microsoft.com/playwright:bionic
 ARG KEG_COPY_LOCAL
 
 # Add a FROM for the tap-base image to we can copy content from it
-ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:master
+ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:develop
 FROM $KEG_BASE_IMAGE as tap-base
 
 # Allows overwriting where the base image is pulled from

--- a/container/values.yml
+++ b/container/values.yml
@@ -14,12 +14,12 @@ env:
   KEG_CONTEXT_PATH: "{{ cli.taps.herkin.path }}"
 
   # Image to use when building herkin
-  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master
+  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:develop
 
   # Image to use when running herkin
   # Even if the dockerfile does not use this in the FROM directive
   # It should still be defined as the image used to run the Tap
-  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/keg-herkin:master
+  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/keg-herkin:develop
 
   # This is a true base image from playwright - Alpine Linux are not supported
   # ref: https://playwright.dev/docs/docker/README/#using-on-ci


### PR DESCRIPTION
**Ticket**: [ZEN-543](https://jira.simpleviewtools.com/browse/ZEN-543)

## Context

* As part of ZEN-543, we determined we should change the default docker image tag from "master" to "develop" for clarity and consistency with the git branches

## Goal

* Update all references of the old "master" to "develop"
* Ensure building images uses "develop"


## Updates
* `container/Dockerfile`
  * updated keg base image to be `tap:develop`
* `container/values.yml`
  * updated tag to "develop"

## Testing

* follow the "setup" section in the testing notes here: https://github.com/simpleviewinc/keg-cli/pull/59
  * you don't have to delete all images, though, just `keg-herkin`
* `keg herkin build`
* verify it is tagged with "develop"
