### PR TITLE
Bundle Automation

### DIFF
--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - HERKIN_SUPPORT_DIR
       - HERKIN_WAYPOINT_DIR
       - DOC_APP_PATH
+      - DOC_BUILD_PATH
       - ENV
       - KEG_EXEC_CMD
       - KEG_DOCKER_EXEC

--- a/container/run.sh
+++ b/container/run.sh
@@ -1,33 +1,30 @@
 #!/usr/bin/env
 
+# Ensure required envs are set
+[[ -z "$KEG_PROXY_PORT" ]] && KEG_PROXY_PORT=19006
+[[ -z "$DOC_APP_PATH" ]] && DOC_APP_PATH=/keg/tap
+[[ -z "$DOC_BUILD_PATH" ]] && DOC_BUILD_PATH=/keg/tap-build
 
 # If the no KEG_DOCKER_EXEC env is set, just sleep forever
 # This is to keep our container running forever
-if [ -z "$KEG_DOCKER_EXEC" ]; then
-  tail -f /dev/null
-  exit 0
+[[ -z "$KEG_DOCKER_EXEC" ]] && tail -f /dev/null && exit 0;
 
-else
-
-  # Ensure the DOC_APP_PATH is set
-  if [ -z "$DOC_APP_PATH" ]; then
-    DOC_APP_PATH=/keg/tap
-  fi
-
-  # cd into the tap repo
+# Serve the bundle and also run the backend api
+keg_herkin_serve(){
   cd $DOC_APP_PATH
+  npx serve $DOC_BUILD_PATH --cors -n -l $KEG_PROXY_PORT &>/dev/null & disown;
+  node ./repos/backend/index.js
+  exit 0
+}
 
-  # Check if no exec command exists, or if it's set to web
-  # Then default it to run the re-theme app
-  if [ -z "$KEG_EXEC_CMD" ] || [ "$KEG_EXEC_CMD" == 'web' ] || [ "$KEG_EXEC_CMD" == 'start' ]; then
-    KEG_EXEC_CMD="dev"
-  fi
-
-  # Start the tap instance
-  echo $"[ KEG-CLI ] Running command 'yarn $KEG_EXEC_CMD'" >&2
-  yarn $KEG_EXEC_CMD
-
+# Check the NODE_ENV, and use that to know which environment to start
+# For non-development environments, we want to serve the bundle if it exists
+if [[ ! " development develop local test " =~ " $NODE_ENV " ]]; then
+  [[ -d "$DOC_BUILD_PATH" ]] && keg_herkin_serve
+  echo $"[ KEG-CLI ] Serve path $DOC_BUILD_PATH does not exist!" >&2
 fi
 
-
-
+# Serve the app bundle in development environemnts
+echo $"[ KEG-CLI ] Running development server!" >&2
+cd $DOC_APP_PATH
+[[ -z "$KEG_EXEC_CMD" ]] && yarn web || yarn $KEG_EXEC_CMD

--- a/container/values.yml
+++ b/container/values.yml
@@ -1,3 +1,15 @@
+actions:
+  tap:
+    build:
+      cmds:
+        - yarn web:build
+        - rm -rf {{ envs.DOC_BUILD_PATH }}
+        - cp -R {{ envs.DOC_CORE_PATH }}/web-build {{ envs.DOC_BUILD_PATH }}
+    serve:
+      detached: true
+      cmds:
+        - npx serve {{ envs.DOC_BUILD_PATH }} --cors -n -l {{ envs.KEG_PROXY_PORT }}
+        - node {{ envs.DOC_APP_PATH }}/repos/backend/index.js
 env:
 
   # --- KEG-CLI ENV CONTEXT --- #
@@ -29,10 +41,11 @@ env:
 
   # --- DOCKER ENV CONTEXT --- #
 
-  # Paths within the docker contianer
+  # Paths within the docker container
   # Used when setting up syncs between host and container
   # Should follow the pattern DOC_<name-of-linked-folder>_PATH
   DOC_APP_PATH: /keg/tap
+  DOC_BUILD_PATH: /keg/tap-build
   DOC_CORE_PATH: /keg/tap/node_modules/keg-core
   DOC_COMPONENTS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
   DOC_RETHEME_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme


### PR DESCRIPTION
**Ticket**: [ZEN-609](https://jira.simpleviewtools.com/browse/ZEN-609)

* This PR should be reviewed along side [this keg-cli pr](https://github.com/simpleviewinc/keg-cli/pull/61)


## Context
* When we run our docker packages on the staging server, there are a number of features that we don't need, like running in development modes
* These features slow down the execution, and in some cases prevent resolving the application url

## Goal
* Automate bundling the application when the docker image is created
* This will allow the staging server serve the bundle instead of using the development server

## Updates
* `container/docker-compose.yml`
  * Added `DOC_BUILD_PATH` env
* `container/run.sh`
  * Updated to run a command based on `NODE_ENV`
  * Allows running the bundled app in non-development environments
* `container/values.yml`
  * Added actions for bundling and serving the app

## Tests

**Setup**
* Pull this PR for the keg-cli => `keg cli && keg pr 61`
* Pull this PR => `keg herkin && keg pr 41`


**Test 1*
* Start the tap => `keg herkin start`
* Connect to the container with => `keg herkin att`
* Then navigate to the keg-core folder => `cd /keg/tap/node_modules/keg-core/`
  * Update the keg-core's `package.json` file
    * Change the `"homepage"` key to be `/`
    * This fix is part of another pr, so we have to do it manually for now
    * [Looks like this](https://prnt.sc/11w5pzq)
* Next open another terminal window run => `keg herkin pack`
  * Ensure it automatically runs the `tap.build` action defined in the `container/Values.yml` file
  * [Looks like this](https://prnt.sc/11w4nxk)
* After it's been built, you can press `ctl+c` to cancel to exit that task
  * Just make sure it finishes building first

**Test 2**
* Leave the keg-herkin container running, but stop **ALL** running servers
  * This includes the one started from the `keg herkin start` command
* Connect to the container with => `keg herkin att`
* Navigate to the build folder with => `cd /keg/tap-build`
  * Ensure the folder exists, and contains the build files
  * [Looks like this](https://prnt.sc/11w4vns)

**Test 3**
* Run the command `bash /keg/tap/container/run.sh`
  * Ensure this starts the development server
  * [Looks like this](https://prnt.sc/11w54jq)
  * Once verified, hit `ctrl+c` to stop the server
* Next, run the command `NODE_ENV=staging bash /keg/tap/container/run.sh`
  * Ensure this starts the bundle server instead
  * Ensure it also starts the backend api server
  * [Looks like this](https://prnt.sc/11w54jq)
  * Navigate to http://herkin-zen-609-automate-package-exec.local.keghub.io/ in your browser
    * Ensure the keg-herkin app resolves in the browser

**Test 4**
* Kill the running keg-herkin container => `keg herkin kill`
* Next, run the command `keg herkin pack run --package keg-herkin:zen-609-automate-package-exec --env staging`
  * This should start the keg-herkin application using the bundled application code
  * [Looks like this](https://prnt.sc/11w71u6)
* Navigate to http://herkin-zen-609-automate-package-exec.local.keghub.io/ in your browser
  * Ensure the keg-herkin app resolves in the browser
  * **NOTE** - Because it's using the `docker package run` task
    * The `mounted docker volume` does not get set, so test files are not loaded
    * Just make sure the app can be loaded in the browser
